### PR TITLE
Fix handling of received crlf characters.

### DIFF
--- a/client/src/js/domain/usecases/textbuffer.js
+++ b/client/src/js/domain/usecases/textbuffer.js
@@ -21,7 +21,7 @@ export function processInput(inputText, key = "", maxLines = 6) {
         }
         return inputText;
     }
-    if (key === KEY_ENTER) {
+    if ([KEY_ENTER, "\n", "\r"].includes(key)) {
         return trimLeadingLines(inputText + TEXT_NEWLINE, maxLines);
     }
     if (key.length !== 1) {

--- a/client/test/textbuffer.test.js
+++ b/client/test/textbuffer.test.js
@@ -66,6 +66,18 @@ describe("Text buffer", function () {
             key: "!",
             expectedNewText: `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod temporum${TEXT_NEWLINE}hello there!`,
         },
+        {
+            name: "should replace linefeed character with newline token",
+            originalText: "hello",
+            key: "\n",
+            expectedNewText: `hello${TEXT_NEWLINE}`,
+        },
+        {
+            name: "should replace carriage return character with newline token",
+            originalText: "hello",
+            key: "\r",
+            expectedNewText: `hello${TEXT_NEWLINE}`,
+        },
     ];
 
     scenarios.forEach(scenario => {


### PR DESCRIPTION
Process received crlf characters to the NEWLINE token ("Enter"). Real users from a browser won't be sending "\n" or "\r", but a bot might.

Related PRs:
* https://github.com/caarmen/retro-chat/pull/12
* https://github.com/caarmen/retro-chat-bot/pull/4